### PR TITLE
Build GhostWire binaries in Ubuntu 22.04 and pin runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,24 +60,12 @@ jobs:
       - name: Throughput test
         run: python3.13 tests/test_throughput.py
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Ensure python3.13 alias
+      - name: Build (Docker, Ubuntu 22.04)
         run: |
-          if ! command -v python3.13 >/dev/null 2>&1; then
-            sudo ln -sf "$(which python)" /usr/local/bin/python3.13
-          fi
-      - name: Install deps
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-      - name: Build
-        run: |
-          bash build/build.sh
+          bash build/build-docker.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Build (Docker, Ubuntu 22.04)
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Ensure python3.13 alias
         run: |
-          bash build/build-docker.sh
+          if ! command -v python3.13 >/dev/null 2>&1; then
+            sudo ln -sf "$(which python)" /usr/local/bin/python3.13
+          fi
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Build
+        run: |
+          bash build/build.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,27 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Ensure python3.13 alias
+        run: |
+          if ! command -v python3.13 >/dev/null 2>&1; then
+            sudo ln -sf "$(which python)" /usr/local/bin/python3.13
+          fi
       - name: Normalize version input
         id: ver
         run: |
           ver="${{ inputs.version }}"
           ver="${ver#v}"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
-      - name: Build (Docker, Ubuntu 22.04)
+      - name: Install deps
         run: |
-          bash build/build-docker.sh
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Build
+        run: |
+          bash build/build.sh
       - name: Create release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,30 +10,18 @@ permissions:
   contents: write
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Ensure python3.13 alias
-        run: |
-          if ! command -v python3.13 >/dev/null 2>&1; then
-            sudo ln -sf "$(which python)" /usr/local/bin/python3.13
-          fi
       - name: Normalize version input
         id: ver
         run: |
           ver="${{ inputs.version }}"
           ver="${ver#v}"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
-      - name: Install deps
+      - name: Build (Docker, Ubuntu 22.04)
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-      - name: Build
-        run: |
-          bash build/build.sh
+          bash build/build-docker.sh
       - name: Create release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
GhostWire release/CI builds were using ubuntu-latest for build/release, which can produce PyInstaller binaries that require newer glibc than Ubuntu 22.04.

This PR pins the workflows to Ubuntu 22.04 without Docker:
- Pin `runs-on: ubuntu-22.04` for the build and release jobs
- Build via build/build.sh (existing script)

The existing integration test job remains in place.
