### PR TITLE
README: use raw.githubusercontent.com for install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ GhostWire is a WebSocket-based reverse tunnel system designed to help users in c
 The server runs in the **censored country** with a **public IP** that can receive incoming connections.
 
 ```bash
-wget https://github.com/frenchtoblerone54/ghostwire/releases/latest/download/install-server.sh -O install-server.sh
+wget https://raw.githubusercontent.com/frenchtoblerone54/ghostwire/main/scripts/install-server.sh -O install-server.sh
 chmod +x install-server.sh
 sudo ./install-server.sh
 ```
@@ -40,7 +40,7 @@ sudo ./install-server.sh
 The client runs on a **VPS in an uncensored country** with unrestricted internet access.
 
 ```bash
-wget https://github.com/frenchtoblerone54/ghostwire/releases/latest/download/install-client.sh -O install-client.sh
+wget https://raw.githubusercontent.com/frenchtoblerone54/ghostwire/main/scripts/install-client.sh -O install-client.sh
 chmod +x install-client.sh
 sudo ./install-client.sh
 ```

--- a/README_FA.md
+++ b/README_FA.md
@@ -41,7 +41,7 @@
 سرور در کشور دارای سانسور با IP عمومی اجرا می‌شود که می‌تواند اتصالات ورودی را دریافت کند.
 
 ```bash
-wget https://github.com/frenchtoblerone54/ghostwire/releases/latest/download/install-server.sh -O install-server.sh
+wget https://raw.githubusercontent.com/frenchtoblerone54/ghostwire/main/scripts/install-server.sh -O install-server.sh
 chmod +x install-server.sh
 sudo ./install-server.sh
 ```
@@ -53,7 +53,7 @@ sudo ./install-server.sh
 کلاینت روی یک VPS در کشور بدون سانسور با دسترسی نامحدود به اینترنت اجرا می‌شود.
 
 ```bash
-wget https://github.com/frenchtoblerone54/ghostwire/releases/latest/download/install-client.sh -O install-client.sh
+wget https://raw.githubusercontent.com/frenchtoblerone54/ghostwire/main/scripts/install-client.sh -O install-client.sh
 chmod +x install-client.sh
 sudo ./install-client.sh
 ```


### PR DESCRIPTION
Updates README.md and README_FA.md to download install-server.sh and install-client.sh via raw.githubusercontent.com (repo path) instead of GitHub release assets.