### PR TITLE
Fix ws_pool_stripe=false still sending sequenced packets

### DIFF
--- a/server.py
+++ b/server.py
@@ -227,7 +227,7 @@ class GhostWireServer:
         self.conn_data_close_seq.pop(conn_id,None)
 
     def should_stripe_data(self):
-        return self.config.ws_pool_enabled and len(self.get_available_child_ids())>1
+        return self.config.ws_pool_enabled and self.config.ws_pool_stripe and self.config.protocol in ("websocket","aiohttp-ws") and len(self.get_available_child_ids())>1
 
     def next_data_seq(self,conn_id):
         seq=self.conn_data_tx_seq.get(conn_id,0)

--- a/updater.py
+++ b/updater.py
@@ -26,7 +26,7 @@ class Updater:
     def get_current_version(self):
         script_path=Path(sys.argv[0])
         if script_path.name.startswith(f"ghostwire-{self.component_name}"):
-            return "v0.13.3"
+            return "v0.13.4"
         return "dev"
 
     async def http_get(self,url,timeout):


### PR DESCRIPTION
When ws_pool_stripe is false, GhostWire should not use the sequenced/striped DATA_SEQ path.

Bug:
- server-side should_stripe_data() ignored ws_pool_stripe and enabled DATA_SEQ whenever ws_pool_enabled and >1 child channels existed.
- This triggers "sequence X missing" warnings even with ws_pool_stripe=false.

Fix:
- Make server should_stripe_data() require ws_pool_stripe=true (and websocket protocol).

Version:
- Bump updater current version to v0.13.4
